### PR TITLE
Fix theme not being installed

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -30,6 +30,6 @@ sphinx:
 # Optional but recommended, declare the Python requirements required
 # to build your documentation
 # See https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
-# python:
-#   install:
-#     - requirements: docs/requirements.txt
+python:
+  install:
+    - requirements: requirements.txt


### PR DESCRIPTION
The new `.readthedocs.yaml` config file had the requirements section commented out at the bottom which was preventing the theme from being installed. This should fix that.